### PR TITLE
Use inlineLarge toolbar title display mode

### DIFF
--- a/Bluerage/Sources/UI/Screens/Agents/AgentsList/AgentsListScreenView.swift
+++ b/Bluerage/Sources/UI/Screens/Agents/AgentsList/AgentsListScreenView.swift
@@ -59,6 +59,7 @@ struct AgentsListScreenView: View {
                     }
                 }
                 .navigationTitle(BluerageStrings.agentsListNavigationTitle)
+                .toolbarTitleDisplayMode(.inlineLarge)
         }
         .background(UIColor.systemGroupedBackground.swiftUI)
         .errorAlert(error: self.viewModel.state.alertError) {

--- a/Bluerage/Sources/UI/Screens/CustomModels/CustomModelsList/CustomModelsListScreenView.swift
+++ b/Bluerage/Sources/UI/Screens/CustomModels/CustomModelsList/CustomModelsListScreenView.swift
@@ -51,6 +51,7 @@ struct CustomModelsListScreenView: View {
                 self.viewModel.connect()
             }
             .navigationTitle(BluerageStrings.customModelsNavigationTitle)
+            .toolbarTitleDisplayMode(.inlineLarge)
             .background(UIColor.systemGroupedBackground.swiftUI)
             .errorAlert(error: self.viewModel.state.alertError) {
                 self.viewModel.resetAlertError()


### PR DESCRIPTION
## Summary
- apply the new inlineLarge toolbar title display mode to the agents and custom models list screens so they stop using large titles

## Testing
- swiftlint ./Bluerage/ --strict *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d47bdbcc788331bdaa962f0d282901

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated toolbar title presentation on the Agents list and Custom Models list screens to use an inline large style.
  - Users will notice a larger, inline title with adjusted spacing and visual hierarchy within the navigation bar.
  - Only the title’s rendering is affected; navigation actions and other toolbar items remain unchanged.
  - No impact on data, performance, or behavior of the lists beyond the visual adjustment to the title area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->